### PR TITLE
FetchFeed: Explicitly connect outport

### DIFF
--- a/components/FetchFeed.coffee
+++ b/components/FetchFeed.coffee
@@ -28,6 +28,7 @@ exports.getComponent = ->
       cb err
     req = request data
     parser = new feedparser
+    c.outPorts.out.connect() # let downstream know we will send
     req.once 'error', (err) ->
       callback err
     req.on 'response', (res) ->


### PR DESCRIPTION
Fixes issue where network stops prematurely because there are no open connections.
This can be seen when running a graph with `noflo-nodejs --batch`, as that kills the process on network stop.
